### PR TITLE
Make new original class instance in construct

### DIFF
--- a/processors/src/main/java/ir/mirrajabi/aptsample/BuilderProcessor.java
+++ b/processors/src/main/java/ir/mirrajabi/aptsample/BuilderProcessor.java
@@ -64,6 +64,7 @@ public class BuilderProcessor extends AbstractProcessor {
                     }
                 MethodSpec privateConstructor = MethodSpec.constructorBuilder()
                         .addModifiers(Modifier.PRIVATE)
+                        .addStatement("this.buildable= new " + element.getSimpleName() + "()")
                         .build();
                 outputType.addMethod(privateConstructor);
                 MethodSpec staticInstance = MethodSpec.methodBuilder("having")


### PR DESCRIPTION
If we launch application, we got error like this.
```javascript
 Caused by: java.lang.NullPointerException: Attempt to write to field 'android.app.Activity ir.mirrajabi.aptsample.TestClass.activity' on a null object reference
                                                                            at ir.mirrajabi.aptsample.TestClassBuilder.activity(TestClassBuilder.java:19)
                                                                            at ir.mirrajabi.aptsample.MainActivity.onCreate(MainActivity.java:12)
                                                                            at android.app.Activity.performCreate(Activity.java:6955)
                                                                            at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1126)
                                                                            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2927)
                                                                            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3045) 
                                                                            at android.app.ActivityThread.-wrap14(ActivityThread.java) 
                                                                            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1642) 
                                                                            at android.os.Handler.dispatchMessage(Handler.java:102) 
                                                                            at android.os.Looper.loop(Looper.java:154) 
                                                                            at android.app.ActivityThread.main(ActivityThread.java:6776) 
                                                                            at java.lang.reflect.Method.invoke(Native Method) 
```

Because `buildable` variable is null, never make new instance.
When we call `having()`, we make new `XXXBuilder`.
We have to make new `buildable`class instance In 'XXXBuilder''s constructor

So I add staement in `constructorBuilder()`